### PR TITLE
Check subfolders when compiling metadata.

### DIFF
--- a/sdg/meta.py
+++ b/sdg/meta.py
@@ -23,7 +23,19 @@ def read_meta(inid, git=True, src_dir=''):
         git_update = sdg.git.get_git_updates(inid, src_dir=src_dir)
         for k in git_update.keys():
             meta[k] = git_update[k]
-            
+
     meta['page_content'] = ''.join(meta_md[1])
+
+    # Now look for all subfolders of the meta folder, which may contain
+    # multilingual metadata, and add them as well.
+    meta_folder = input_path(None, ftype='meta', src_dir=src_dir)
+    languages = next(os.walk(meta_folder))[1]
+    for language in languages:
+        i18n_fr = os.path.join(meta_folder, language, inid + '.md')
+        if os.path.isfile(i18n_fr):
+            i18n_meta_md = yamlmd.read_yamlmd(i18n_fr)
+            i18n_meta = dict(i18n_meta_md[0])
+            meta[language] = i18n_meta
+            meta[language]['page_content'] = ''.join(i18n_meta_md[1])
 
     return meta


### PR DESCRIPTION
This addition looks into subfolders when compiling metadata. This allows for the possibility of multilingual metadata, where the translated fields of included in subfolders for each language, where they can "inherit" the non-translated fields not included.